### PR TITLE
[enhancing] Sphinx Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,11 @@ copyright = "2024, maxpareschi, jakubjezek001, doerp"
 author = lablib.__author__
 release = lablib.__version__
 
-extensions = ["sphinx.ext.autodoc"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "revitron_sphinx_theme"
+]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/lablib/lib/imageio.py
+++ b/lablib/lib/imageio.py
@@ -217,8 +217,8 @@ class SequenceInfo:
 
         Currently only supports EXR files. Needs to be extended and tested for other formats.
 
-        Args:
-            directory Any[str, Path]: Path to the directory to be scanned.
+        Attributes:
+            directory (Any[str, Path]): Path to the directory to be scanned.
 
         Returns:
             List[SequenceInfo]: List of all found image sequences

--- a/lablib/lib/imageio.py
+++ b/lablib/lib/imageio.py
@@ -220,7 +220,9 @@ class SequenceInfo:
         Args:
             directory Any[str, Path]: Path to the directory to be scanned.
 
-        :returns: List[SequenceInfo]
+        Returns:
+            List[SequenceInfo]: List of all found image sequences
+                as `SequenceInfo`.
         """
         log.info(f"Scanning {directory}")
         if not isinstance(directory, Path):
@@ -256,7 +258,8 @@ class SequenceInfo:
     def frames(self) -> List[int]:
         """Property for getting a list of all frame numbers in the sequence.
 
-        :returns: List[int]
+        Returns:
+            List[int]: List of all frame numbers in the sequence.
         """
         return self.imageinfos
 
@@ -264,7 +267,8 @@ class SequenceInfo:
     def start_frame(self) -> int:
         """Property for the lowest frame number in the sequence.
 
-        :returns: int
+        Returns:
+            int: The lowest frame number in the sequence.
         """
         return min(self.frames).frame_number
 

--- a/lablib/operators/repositions.py
+++ b/lablib/operators/repositions.py
@@ -12,6 +12,29 @@ from lablib.lib.utils import (
 
 @dataclass
 class Transform:
+    """Transform operator for repositioning images.
+
+    This operator is used to apply transformations to images.
+    The transformations are applied in the following order:
+        translate, rotate, scale, center, invert, skewX, skewY.
+
+    The skew_order parameter determines the order in which the skewX and skewY
+    transformations are applied.
+
+    Attributes:
+        translate (List[float]): The translation vector.
+        rotate (float): The rotation angle in degrees.
+        scale (List[float]): The scaling vector.
+        center (List[float]): The center of the transformation.
+        invert (bool): Invert the transformation.
+        skewX (float): The skew in the X direction.
+        skewY (float): The skew in the Y direction.
+        skew_order (str): The order in which the skewX and skewY
+            transformations are applied.
+
+    Returns:
+        List[str]: The arguments for the OIIO command.
+    """
     translate: List[float] = field(default_factory=lambda: [0.0, 0.0])
     rotate: float = 0.0
     # needs to be treated as a list of floats but can be single float
@@ -23,6 +46,11 @@ class Transform:
     skew_order: str = "XY"
 
     def to_oiio_args(self):
+        """Convert the Transform object to OIIO arguments.
+
+        Returns:
+            List[str]: The arguments for the OIIO command.
+        """
         matrix = calculate_matrix(
             t=self.translate, r=self.rotate, s=self.scale, c=self.center
         )
@@ -35,6 +63,14 @@ class Transform:
 
     @classmethod
     def from_node_data(cls, data):
+        """Create a Transform object from node data.
+
+        Attributes:
+            data (dict): The node data.
+
+        Returns:
+            Transform: The Transform object.
+        """
         scale = data.get("scale", [0.0, 0.0])
         if isinstance(scale, (int, float)):
             scale = [scale, scale]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ pytest = "^6.2.0"
 opencolorio = "^2.3.2"
 selenium = "^4.20.0"
 sphinx = "^7.3.7"
+sphinx-autoapi = "^2.0.1"
+sphinxcontrib-napoleon = "^0.7"
+revitron-sphinx-theme = { git = "https://github.com/revitron/revitron-sphinx-theme.git", branch = "master" }
+
+[tool.poetry.extras]
+docs = ["Sphinx", "sphinxcontrib-napoleon"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Some additional changes on Sphinx Napoleon docstring compatibility adjustments. I have also added some docstring examples which sere resolving into following example HTML:

![image](https://github.com/ynput/LabLib/assets/40640033/f3b46135-4a37-468e-9471-09e60b3d9ce2)
![image](https://github.com/ynput/LabLib/assets/40640033/bad22ff8-cc3a-416e-8476-3dd2a07f0823)

![image](https://github.com/ynput/LabLib/assets/40640033/ade10f57-a31f-4ae2-81c8-d2b5579138ad)


## Following is the recomanded docstring style:
```
"""Classmethod for scanning a directory for image sequences.

        Currently only supports EXR files. Needs to be extended and tested for other formats.

        Attributes:
            directory (Any[str, Path]): Path to the directory to be scanned.

        Returns:
            List[SequenceInfo]: List of all found image sequences
                as `SequenceInfo`.
        """
```
Inspired by https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html


This PR is enhancing #17 