### PR TITLE
Rework HTML slate renderer.

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: install LabLib
         run: |
-          $env:POETRY_HOME="$repo_root\.poetry"
-          .\.poetry\bin\poetry.exe lock
           .\start.ps1 install
 
       - name: get dependencies

--- a/lablib/generators/__init__.py
+++ b/lablib/generators/__init__.py
@@ -1,9 +1,10 @@
 """Generator module to be used by Processors and Renderers."""
 
 from .ocio_config import OCIOConfigFileGenerator
-from .slate_html import SlateHtmlGenerator
+from .slate_html import SlateHtmlGenerator, SlateFillMode
 
 __all__ = [
     "OCIOConfigFileGenerator",
     "SlateHtmlGenerator",
+    "SlateFillMode"
 ]

--- a/lablib/generators/slate_html.py
+++ b/lablib/generators/slate_html.py
@@ -94,7 +94,7 @@ class SlateHtmlGenerator:
         options.add_argument("--disable-dev-shm-usage")
         options.add_argument("--disable-extensions")
         options.add_argument("--disable-gpu")
-        options.add_argument(f"--force-device-scale-factor=1")
+        options.add_argument("--force-device-scale-factor=1")
         options.add_experimental_option("excludeSwitches", ["enable-logging"])
         self._driver = webdriver.Chrome(options=options)
 

--- a/lablib/generators/slate_html.py
+++ b/lablib/generators/slate_html.py
@@ -94,6 +94,7 @@ class SlateHtmlGenerator:
         options.add_argument("--disable-dev-shm-usage")
         options.add_argument("--disable-extensions")
         options.add_argument("--disable-gpu")
+        options.add_argument(f"--force-device-scale-factor=1")
         options.add_experimental_option("excludeSwitches", ["enable-logging"])
         self._driver = webdriver.Chrome(options=options)
 

--- a/lablib/lib/utils.py
+++ b/lablib/lib/utils.py
@@ -193,13 +193,6 @@ def call_ffprobe(filepath: str | Path) -> dict:
     return result
 
 
-class format_dict(dict):
-    _placeholder = "**MISSING**"
-
-    def __missing__(self, key) -> str:
-        return self._placeholder
-
-
 def offset_timecode(tc: str, frame_offset: int = None, fps: float = None) -> str:
     if not frame_offset:
         frame_offset = -1

--- a/lablib/renderers/slate_render.py
+++ b/lablib/renderers/slate_render.py
@@ -133,6 +133,7 @@ class SlateRenderer(BasicRenderer):
         if debug:
             cmd.extend(["--debug", "-v"])
 
+        cmd.extend(["-resize", f"{self._slate_proc.width}x{self._slate_proc.height}"])
         cmd.extend(["-o", self.destination])
         call_cmd(cmd)
 

--- a/lablib/renderers/slate_render.py
+++ b/lablib/renderers/slate_render.py
@@ -133,7 +133,6 @@ class SlateRenderer(BasicRenderer):
         if debug:
             cmd.extend(["--debug", "-v"])
 
-        cmd.extend(["-resize", f"{self._slate_proc.width}x{self._slate_proc.height}"])
         cmd.extend(["-o", self.destination])
         call_cmd(cmd)
 

--- a/templates/slates/slate_generic/slate_generic.html
+++ b/templates/slates/slate_generic/slate_generic.html
@@ -6,8 +6,8 @@
         <!--<img class="logo_footer" src="logo.svg" />-->
         <div class="main-container">
             <div class="info-container">
-                <div class="title">{project[name]}</div>
-                <div class="subtitle">{asset}_{task[short]}_v{@version}</div>
+                <div class="title">{project_name}</div>
+                <div class="subtitle">{asset}_{task_short}_v{@version}</div>
                 <div class="info-entry">
                     <div class="info-desc">Date:</div>
                     <div class="info-text">{dd} {mmm} {yyyy}</div>
@@ -26,7 +26,7 @@
                 </div>
                 <div class="info-entry">
                     <div class="info-desc">Intent:</div>
-                    <div class="info-text">{intent[value]}</div>
+                    <div class="info-text">{intent}</div>
                 </div>
                 <div class="info-entry">
                     <div class="info-desc">Notes:</div>

--- a/templates/slates/slate_generic/slate_generic.html
+++ b/templates/slates/slate_generic/slate_generic.html
@@ -14,7 +14,7 @@
                 </div>
                 <div class="info-entry">
                     <div class="info-desc">Length:</div>
-                    <div class="info-text">{frameStart} - {frameEnd}</div>
+                    <div class="info-text">{frame_start} - {frame_end}</div>
                 </div>
                 <div class="info-entry">
                     <div class="info-desc">Resolution:</div>

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -45,11 +45,13 @@ def source_dir(test_staging_dir, request):
         and after each tests.
     """
     # Prepare a temporary directory with a copy of default sequence
-    temp_dir = os.path.join(
-        test_staging_dir,
-        request.node.name
-    )
-    os.mkdir(temp_dir)
+    temp_dir = test_staging_dir / request.node.name
+    
+    # remove folder with content
+    shutil.rmtree(temp_dir, ignore_errors=True)
+    
+    # create temp folder again
+    temp_dir.mkdir()
 
     for img in DEFAULT_SEQUENCE.frames:
         new_path = pathlib.Path(temp_dir) / img.filename

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -19,7 +19,8 @@ SLATE_TEMPLATE_FILE = os.path.join(
     "slate_generic.html"
 )
 DEFAULT_SEQUENCE_PATH = "resources/public/plateMain/v002"
-DEFAULT_SEQUENCE = SequenceInfo.scan(DEFAULT_SEQUENCE_PATH)[0]    
+DEFAULT_SEQUENCE = SequenceInfo.scan(DEFAULT_SEQUENCE_PATH)[0]
+IS_RUNNING_ON_GH_ACTION = bool(os.getenv("GITHUB_WORKFLOW"))
 
 
 def _run_slate_renderer(
@@ -61,6 +62,7 @@ def source_dir():
     shutil.rmtree(temp_dir)
 
 
+@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_missing_keys():
     """ An Exception should raise if any key defined in the 
         template but missing in the provided data.
@@ -73,6 +75,7 @@ def test_Slaterenderer_missing_keys():
         _run_slate_renderer(generator)
 
 
+@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_default(source_dir):
     """ Ensure a valid HD slate is generated from default.
     """
@@ -99,6 +102,7 @@ def test_Slaterenderer_default(source_dir):
     assert slate_frame.height == 1080
 
 
+@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_4K(source_dir):
     """ Ensure a valid 4K slate.
     """
@@ -127,6 +131,7 @@ def test_Slaterenderer_4K(source_dir):
     assert slate_frame.height == 2048
 
 
+@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_explicit_output(source_dir):
     """ Ensure a valid HD slate can be generated to a predefined output.
     """

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -1,0 +1,148 @@
+import os
+import pathlib
+import tempfile
+import shutil
+
+import pytest
+
+from lablib.lib import SequenceInfo
+from lablib.generators import SlateHtmlGenerator
+from lablib.renderers import SlateRenderer
+
+
+SLATE_TEMPLATE_FILE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "templates",
+    "slates",
+    "slate_generic",
+    "slate_generic.html"
+)
+DEFAULT_SEQUENCE_PATH = "resources/public/plateMain/v002"
+DEFAULT_SEQUENCE = SequenceInfo.scan(DEFAULT_SEQUENCE_PATH)[0]    
+
+
+def _run_slate_renderer(
+        generator: SlateHtmlGenerator,
+        sequence: SequenceInfo = None,
+        output_path: str = None,
+    ):
+    """ Run a renderer associated with the provided
+        generator and source sequence.
+    """
+    sequence = sequence or DEFAULT_SEQUENCE
+    renderer = SlateRenderer(
+        generator,
+        sequence,
+        destination=output_path,
+    )
+
+    renderer.render()
+
+
+@pytest.fixture()
+def source_dir():
+    """ Prepare are clean source sequence
+        and after each tests.
+    """
+    # Prepare a temporary directory with a copy of default sequence
+    temp_dir = tempfile.mkdtemp()
+    for img in DEFAULT_SEQUENCE.frames:
+        new_path = pathlib.Path(temp_dir) / img.filename
+
+        try:
+            new_path.symlink_to(img.path)
+        except OSError:
+            shutil.copy(img.filepath, new_path)
+
+    yield temp_dir
+
+    # Remove all temporary directory content.
+    shutil.rmtree(temp_dir)
+
+
+def test_Slaterenderer_missing_keys():
+    """ An Exception should raise if any key defined in the 
+        template but missing in the provided data.
+    """
+    with pytest.raises(ValueError):
+        generator = SlateHtmlGenerator(
+            {"missing": "data"},
+            SLATE_TEMPLATE_FILE,
+        )
+        _run_slate_renderer(generator)
+
+
+def test_Slaterenderer_default(source_dir):
+    """ Ensure a valid HD slate is generated from default.
+    """
+    source_sequence =  SequenceInfo.scan(source_dir)[0]
+    generator = SlateHtmlGenerator(
+        {
+            "project": {"name": "test_project"},
+            "intent": {"value": "test_intent"},            
+            "task": {"short": "test_task"},
+            "asset": "test_asset",
+            "comment": "some random comment",
+            "scope": "test_scope",
+            "@version": "123",
+        },
+        SLATE_TEMPLATE_FILE,
+    )
+    _run_slate_renderer(generator, sequence=source_sequence)
+
+    edited_sequence = SequenceInfo.scan(source_dir)[0]
+    slate_frame = edited_sequence.frames[0]
+
+    assert len(edited_sequence.frames) == len(source_sequence.frames) + 1
+    assert slate_frame.width == 1920
+    assert slate_frame.height == 1080
+
+
+def test_Slaterenderer_4K(source_dir):
+    """ Ensure a valid 4K slate.
+    """
+    source_sequence =  SequenceInfo.scan(source_dir)[0]
+    generator = SlateHtmlGenerator(
+        {
+            "project": {"name": "test_project"},
+            "intent": {"value": "test_intent"},            
+            "task": {"short": "test_task"},
+            "asset": "test_asset",
+            "comment": "some random comment",
+            "scope": "test_scope",
+            "@version": "123",
+        },
+        SLATE_TEMPLATE_FILE,
+        width=4096,
+        height=2048,
+    )
+    _run_slate_renderer(generator, sequence=source_sequence)
+
+    edited_sequence = SequenceInfo.scan(source_dir)[0]
+    slate_frame = edited_sequence.frames[0]
+
+    assert len(edited_sequence.frames) == len(source_sequence.frames) + 1
+    assert slate_frame.width == 4096
+    assert slate_frame.height == 2048
+
+
+def test_Slaterenderer_explicit_output(source_dir):
+    """ Ensure a valid HD slate can be generated to a predefined output.
+    """
+    expected_output = pathlib.Path(source_dir) / "output.exr"
+    generator = SlateHtmlGenerator(
+        {
+            "project": {"name": "test_project"},
+            "intent": {"value": "test_intent"},            
+            "task": {"short": "test_task"},
+            "asset": "test_asset",
+            "comment": "some random comment",
+            "scope": "test_scope",
+            "@version": "123",
+        },
+        SLATE_TEMPLATE_FILE,
+    )
+    _run_slate_renderer(generator, output_path=expected_output)
+
+    assert os.path.exists(expected_output)

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import tempfile
 import shutil
 
 import pytest
@@ -41,12 +40,17 @@ def _run_slate_renderer(
 
 
 @pytest.fixture()
-def source_dir(test_staging_dir):
+def source_dir(test_staging_dir, request):
     """ Prepare are clean source sequence
         and after each tests.
     """
     # Prepare a temporary directory with a copy of default sequence
-    temp_dir = tempfile.mkdtemp(dir=test_staging_dir)
+    temp_dir = os.path.join(
+        test_staging_dir,
+        request.node.name
+    )
+    os.mkdir(temp_dir)
+
     for img in DEFAULT_SEQUENCE.frames:
         new_path = pathlib.Path(temp_dir) / img.filename
         shutil.copy(img.filepath, new_path)

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -41,20 +41,17 @@ def _run_slate_renderer(
 
 
 @pytest.fixture()
-def source_dir():
+def source_dir(test_staging_dir):
     """ Prepare are clean source sequence
         and after each tests.
     """
     # Prepare a temporary directory with a copy of default sequence
-    temp_dir = tempfile.mkdtemp(dir=os.getcwd())
+    temp_dir = tempfile.mkdtemp(dir=test_staging_dir)
     for img in DEFAULT_SEQUENCE.frames:
         new_path = pathlib.Path(temp_dir) / img.filename
         shutil.copy(img.filepath, new_path)
 
     yield temp_dir
-
-    # Remove all temporary directory content.
-    shutil.rmtree(temp_dir)
 
 
 def test_Slaterenderer_missing_keys():

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -46,14 +46,10 @@ def source_dir():
         and after each tests.
     """
     # Prepare a temporary directory with a copy of default sequence
-    temp_dir = tempfile.mkdtemp()
+    temp_dir = tempfile.mkdtemp(dir=os.getcwd())
     for img in DEFAULT_SEQUENCE.frames:
         new_path = pathlib.Path(temp_dir) / img.filename
-
-        try:
-            new_path.symlink_to(img.path)
-        except OSError:
-            shutil.copy(img.filepath, new_path)
+        shutil.copy(img.filepath, new_path)
 
     yield temp_dir
 

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -20,7 +20,6 @@ SLATE_TEMPLATE_FILE = os.path.join(
 )
 DEFAULT_SEQUENCE_PATH = "resources/public/plateMain/v002"
 DEFAULT_SEQUENCE = SequenceInfo.scan(DEFAULT_SEQUENCE_PATH)[0]
-IS_RUNNING_ON_GH_ACTION = bool(os.getenv("GITHUB_WORKFLOW"))
 
 
 def _run_slate_renderer(
@@ -61,8 +60,6 @@ def source_dir():
     # Remove all temporary directory content.
     shutil.rmtree(temp_dir)
 
-
-@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_missing_keys():
     """ An Exception should raise if any key defined in the 
         template but missing in the provided data.
@@ -75,7 +72,6 @@ def test_Slaterenderer_missing_keys():
         _run_slate_renderer(generator)
 
 
-@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_default(source_dir):
     """ Ensure a valid HD slate is generated from default.
     """
@@ -102,7 +98,6 @@ def test_Slaterenderer_default(source_dir):
     assert slate_frame.height == 1080
 
 
-@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_4K(source_dir):
     """ Ensure a valid 4K slate.
     """
@@ -131,7 +126,6 @@ def test_Slaterenderer_4K(source_dir):
     assert slate_frame.height == 2048
 
 
-@pytest.mark.skipif(IS_RUNNING_ON_GH_ACTION, reason="cause access violation on GH")
 def test_Slaterenderer_explicit_output(source_dir):
     """ Ensure a valid HD slate can be generated to a predefined output.
     """


### PR DESCRIPTION
## Changelog Description
Addresses the TODOs for HTML slate renderer:
* Turn generator and renderer as regular python classes and not dataclasses anymore
* Add unit tests

Changed behavior:
* Renderer will now raise a `ValueError` by default if the provided data does not fill up all of the expected template field 
* Slate can ignore missing data and still goes through with the newly added `SlateFillMode.HIDE_FIELD_WHEN_MISSING` mode
* Provide default data for `resolution`, `date` and input `frame range`

## Additional info
![image](https://github.com/user-attachments/assets/2d265ea7-46ae-42e7-911f-ed2a2bd1d8fb)

Contributes to #26 
Depends on #30 

## Testing notes:

1. New automated tests have been added under `tests/test_renderers_slate.py`
2. Either use poetry or we can directly run helper `.\start.ps1 test` (Windows only)
