### PR TITLE
Fix broken tests on GitHub actions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.9.1,<3.10"
 opentimelineio = "^0.16.0"
-opencolorio = "^2.3.2"
+opencolorio = "2.3.2"
 selenium = "4.16.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Changelog Description
While everything still works fine locally, LabLib tests as GitHub action seems suddenly broken since a couple of weeks:
* https://github.com/ynput/LabLib/actions/runs/11352264466
* https://github.com/ynput/LabLib/actions/runs/10013629680 (latest release is OK)


After some investigation I realized the culprit seems to come from a recent [OpenColorIO Release](https://github.com/AcademySoftwareFoundation/OpenColorIO/releases/tag/v2.4.0) 2 weeks ago.
Fixing it back to the previous version seems to make it work back.

@jakubjezek001 @tweak-wtf, I'm not sure this is the best fix for the long-term but I cannot find have anything better for now.

## Additional info

Issue is quite weird:
```
Run .\start.ps1 test
Windows fatal exception: access violation

Current thread 0x00001304 (most recent call first):
  File "<frozen importlib._bootstrap>", line 228 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line [11](https://github.com/ynput/LabLib/actions/runs/11352264466/job/31574650242#step:9:12)73 in create_module
```

And what I could find on Google was not very meaningful.
https://github.com/spyder-ide/spyder/issues/20909
https://github.com/pytest-dev/pytest/issues/7634

## Testing notes:

GitHub actions are now working.
