### PR TITLE
Bugfix/oiio write tc attribute

### DIFF
--- a/lablib/renderers/slate_render.py
+++ b/lablib/renderers/slate_render.py
@@ -127,7 +127,7 @@ class SlateRenderer(BasicRenderer):
                 "R,G,B",
                 "--attrib:type=timecode",
                 "smpte:TimeCode",
-                f"""'{timecode.replace('"', "")}'""",
+                timecode,
             ]
         )
         if debug:

--- a/tests/test_renderers_slate.py
+++ b/tests/test_renderers_slate.py
@@ -102,6 +102,7 @@ def test_Slaterenderer_missing_keys_hide(source_dir):
     assert len(edited_sequence.frames) == len(source_sequence.frames) + 1
     assert slate_frame.width == 1920
     assert slate_frame.height == 1080
+    assert slate_frame.timecode == "02:10:04:16"
 
 
 def test_Slaterenderer_default(source_dir):
@@ -128,6 +129,7 @@ def test_Slaterenderer_default(source_dir):
     assert len(edited_sequence.frames) == len(source_sequence.frames) + 1
     assert slate_frame.width == 1920
     assert slate_frame.height == 1080
+    assert slate_frame.timecode == "02:10:04:16"
 
 
 def test_Slaterenderer_4K(source_dir):
@@ -156,6 +158,7 @@ def test_Slaterenderer_4K(source_dir):
     assert len(edited_sequence.frames) == len(source_sequence.frames) + 1
     assert slate_frame.width == 4096
     assert slate_frame.height == 2048
+    assert slate_frame.timecode == "02:10:04:16"
 
 
 def test_Slaterenderer_explicit_output(source_dir):


### PR DESCRIPTION
## Changelog Description
- implements suggestion raised here https://github.com/ynput/LabLib/pull/27#discussion_r1815561136
- adds assertions for timecode in slate unit tests


## Additional info
Noticed a bug in `SequenceInfo.frames` , the return type doesn't match the type hint. Started branch `bugfix/sequenceinfo-frame-correct-return-type`
