### PR TITLE
AY-5418_Fixing Hiero effect json order of processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ results/
 .python-version
 
 test_results/
+.pytest_cache/
 docs/_build/

--- a/lablib/processors/ayon_hiero_effect_file.py
+++ b/lablib/processors/ayon_hiero_effect_file.py
@@ -79,8 +79,8 @@ class AYONHieroEffectsFileProcessor(object):
 
         all_ops = [v for _, v in ops_data.items() if isinstance(v, dict)]
 
-        # TODO: what if there are multiple layer citizens with subTrackIndex
-        all_ops.sort(key=lambda op: op["subTrackIndex"])
+        # first sort all by trackIndex and then subtrackIndex
+        all_ops.sort(key=lambda op: (op["trackIndex"], op["subTrackIndex"]))
 
         for value in all_ops:
             class_name = value["class"]


### PR DESCRIPTION
This is fixing the correct order of effects to be processed following first `trackIndex` and then `subitemTrackIndex`. This is then producing correct look. 