### PR TITLE
Refactors type hints for better readability

### DIFF
--- a/lablib/generators/ocio_config.py
+++ b/lablib/generators/ocio_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import logging
 import uuid
-from typing import List, Union, Dict, Optional
+from typing import Union, Optional
 from pathlib import Path
 
 import PyOpenColorIO as OCIO
@@ -20,20 +20,20 @@ class OCIOConfigFileGenerator:
         context (str): The context of the OCIO Config file.
         config_path (Optional[str]): The path to the OCIO Config file.
         family (Optional[str]): The family of the OCIO Config file.
-        ocio_objects (Optional[List[OCIO.Transform]]): A list of OCIO Transform
+        ocio_objects (Optional[list[OCIO.Transform]]): A list of OCIO Transform
             objects.
         working_space (Optional[str]): The working space of the OCIO Config
             file.
         target_view_space (Optional[str]): The target view space of the OCIO
             Config file. For views to be using specific color spaces
             different from working space.
-        views (Optional[List[str]]): A list of views.
+        views (Optional[list[str]]): A list of views.
         description (Optional[str]): The description of the OCIO Config file.
         staging_dir (Optional[str]): The staging directory of the OCIO Config
             file.
-        environment_variables (Optional[Dict]): A dictionary of environment
+        environment_variables (Optional[dict]): A dictionary of environment
             variables.
-        search_paths (Optional[List[str]]): A list of search paths.
+        search_paths (Optional[list[str]]): A list of search paths.
 
     Example:
         >>> from lablib.operators import LUT
@@ -61,28 +61,28 @@ class OCIOConfigFileGenerator:
     log: logging.Logger = log
 
     _description: str
-    _vars: Dict[str, str] = {}
-    _views: List[str] = []
+    _vars: dict[str, str] = {}
+    _views: list[str] = []
     _config_path: Path  # OCIO Config file
     _ocio_config: OCIO.Config  # OCIO Config object
-    _ocio_search_paths: List[str] = []
+    _ocio_search_paths: list[str] = []
     _ocio_config_name: str = "config.ocio"
     _dest_path: str = ""
-    _ocio_objects: List[OCIO.Transform] = []
+    _ocio_objects: list[OCIO.Transform] = []
 
     def __init__(
         self,
         context: str,
         family: Optional[str] = None,
-        ocio_objects: Optional[List[OCIO.Transform]] = None,
+        ocio_objects: Optional[list[OCIO.Transform]] = None,
         config_path: Optional[str] = None,
         working_space: Optional[str] = None,
         target_view_space: Optional[str] = None,
-        views: Optional[List[str]] = None,
+        views: Optional[list[str]] = None,
         description: Optional[str] = None,
         staging_dir: Optional[str] = None,
-        environment_variables: Optional[Dict] = None,
-        search_paths: Optional[List[str]] = None,
+        environment_variables: Optional[dict] = None,
+        search_paths: Optional[list[str]] = None,
         logger: logging.Logger = None,
     ):
 
@@ -163,7 +163,7 @@ class OCIOConfigFileGenerator:
         """
         self._ocio_config_name = name
 
-    def set_views(self, *args: Union[str, List[str]]) -> None:
+    def set_views(self, *args: Union[str, list[str]]) -> None:
         """Set the views for the OCIO Config file.
 
         Attention:
@@ -175,7 +175,7 @@ class OCIOConfigFileGenerator:
         self.clear_views()
         self.append_views(*args)
 
-    def set_search_paths(self, *args: Union[str, List[str]]) -> None:
+    def set_search_paths(self, *args: Union[str, list[str]]) -> None:
         self.append_search_paths(*args)
 
     def set_ocio_objects(self, *args) -> None:
@@ -238,7 +238,7 @@ class OCIOConfigFileGenerator:
             else:
                 self._ocio_objects.append(arg)
 
-    def append_views(self, *args: Union[str, List[str]]) -> None:
+    def append_views(self, *args: Union[str, list[str]]) -> None:
         """Append views.
 
         Arguments:
@@ -274,22 +274,22 @@ class OCIOConfigFileGenerator:
         """
         return self._ocio_config.getDescription()
 
-    def _get_search_paths_from_config(self) -> List[str]:
+    def _get_search_paths_from_config(self) -> list[str]:
         """Return the search paths from the OCIO Config file.
 
         Returns:
-            List[str]: A list of search paths.
+            list[str]: A list of search paths.
         """
         return list(self._ocio_config.getSearchPaths())
 
-    def _sanitize_search_paths(self, paths: List[str]) -> None:
+    def _sanitize_search_paths(self, paths: list[str]) -> None:
         """Sanitize the search paths.
 
         It will check if the path is a file or a directory and add it to the
         search paths. It will also replace any variables found in the path.
 
         Arguments:
-            paths (List[str]): A list of search paths.
+            paths (list[str]): A list of search paths.
         """
         real_paths = []
         for p in paths:
@@ -433,18 +433,18 @@ class OCIOConfigFileGenerator:
         with open(dest.as_posix(), "w") as f:
             f.write(self._ocio_config.serialize())
 
-    def _get_search_paths_lines(self) -> List[str]:
+    def _get_search_paths_lines(self) -> list[str]:
         """Add search paths to the OCIO Config file.
 
         INFO: This is temporary hacky way to add search paths to the
             OCIO since OCIO is ignoring official api methods `addSearchPath()`.
 
         Arguments:
-            paths (List[str]): A list of search paths.
+            paths (list[str]): A list of search paths.
         """
         return [f"  - {path}" for path in self._ocio_search_paths]
 
-    def _get_environment_variables_lines(self) -> List[str]:
+    def _get_environment_variables_lines(self) -> list[str]:
         """Add environment variables to the OCIO Config file.
 
         INFO: This is temporary hacky way to add environment variables to the
@@ -452,7 +452,7 @@ class OCIOConfigFileGenerator:
             methods `addEnvironmentVar()`.
 
         Returns:
-            List[str]: A list of environment variables.
+            list[str]: A list of environment variables.
         """
         return [f"  {k}: {v}" for k, v in self._vars.items()]
 
@@ -477,11 +477,11 @@ class OCIOConfigFileGenerator:
         self._dest_path = dest
         return dest
 
-    def get_oiiotool_cmd(self) -> List:
+    def get_oiiotool_cmd(self) -> list:
         """Return arguments for the oiiotool command.
 
         Returns:
-            List: The arguments for the oiiotool command.
+            list: The arguments for the oiiotool command.
         """
         return [
             "--colorconfig",

--- a/lablib/generators/slate_html.py
+++ b/lablib/generators/slate_html.py
@@ -4,7 +4,6 @@ import collections
 import datetime
 from enum import Enum
 import shutil
-from typing import List, Dict
 from pathlib import Path
 
 from selenium import webdriver
@@ -25,7 +24,7 @@ class SlateHtmlGenerator:
     """Class to generate a slate from a template.
 
     Attributes:
-        data (dict): A dictionary containing the data to be formatted in the template.    
+        data (dict): A dictionary containing the data to be formatted in the template.
         slate_template_path (str): The path to the template.
         width (int): The width of the slate.
         height (int): The height of the slate.
@@ -41,12 +40,12 @@ class SlateHtmlGenerator:
 
     def __init__(
         self,
-        data: Dict,
+        data: dict,
         slate_template_path: str,
         width: int = None,
         height: int = None,
         staging_dir: str = None,
-        source_files: List[imageio.ImageInfo] = None,
+        source_files: list[imageio.ImageInfo] = None,
         is_source_linear: bool = None,
         slate_fill_mode: SlateFillMode = None
     ):
@@ -130,7 +129,7 @@ class SlateHtmlGenerator:
         """Set the slate template path.
 
         Arguments:
-            path (str): The new path to the slate template path.    
+            path (str): The new path to the slate template path.
         """
         self._slate_template_path = Path(path).resolve().as_posix()
 
@@ -330,14 +329,14 @@ class SlateHtmlGenerator:
             )
 
     def create_base_slate(self) -> None:
-        """Prepare and create base slate. 
+        """Prepare and create base slate.
         """
         self._stage_slate()
         self._format_slate()
         self._setup_base_slate()
         self._set_thumbnail_sources()
 
-    def get_oiiotool_cmd(self) -> List:
+    def get_oiiotool_cmd(self) -> list:
         """ Get the oiiotool command to run for slate generation.
 
         Returns:

--- a/lablib/lib/imageio.py
+++ b/lablib/lib/imageio.py
@@ -6,7 +6,7 @@ import re
 import logging
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Optional
 
 import opentimelineio.opentime as opentime
 
@@ -197,12 +197,12 @@ class SequenceInfo:
 
     Attributes:
         path Any[Path, str]: Path to the image sequence directory.
-        imageinfos List[ImageInfo]: List of all files as `ImageInfo` to be
+        imageinfos list[ImageInfo]: list of all files as `ImageInfo` to be
             used.
     """
 
     path: Path = field(default_factory=Path)
-    imageinfos: List[ImageInfo] = field(default_factory=list)
+    imageinfos: list[ImageInfo] = field(default_factory=list)
 
     def __post_init__(self):
         if not all([self.path, self.imageinfos]):
@@ -211,7 +211,7 @@ class SequenceInfo:
             )
 
     @classmethod
-    def scan(cls, directory: str | Path) -> List[SequenceInfo]:
+    def scan(cls, directory: str | Path) -> list[SequenceInfo]:
         """Scan a directory for a list of images.
 
         Attention:
@@ -223,7 +223,7 @@ class SequenceInfo:
                 to be scanned.
 
         Returns:
-            List[SequenceInfo]: List of all found sequences.
+            list[SequenceInfo]: list of all found sequences.
         """
         log.info(f"Scanning {directory}")
         if not isinstance(directory, Path):
@@ -232,7 +232,7 @@ class SequenceInfo:
         if not directory.is_dir():
             raise NotImplementedError(f"{directory} is no directory")
 
-        files_map: Dict[Path, ImageInfo] = {}
+        files_map: dict[Path, ImageInfo] = {}
         for item in directory.iterdir():
             if not item.is_file():
                 continue
@@ -256,8 +256,8 @@ class SequenceInfo:
         ]
 
     @property
-    def frames(self) -> List[int]:
-        """:obj:`List[int]`: List of all available frame numbers in the sequence."""  # noqa
+    def frames(self) -> list[int]:
+        """:obj:`list[int]`: list of all available frame numbers in the sequence."""  # noqa
         return [ii.frame_number for ii in self.imageinfos]
 
     @property

--- a/lablib/lib/utils.py
+++ b/lablib/lib/utils.py
@@ -5,13 +5,14 @@ TODO:
 """
 
 from __future__ import annotations
+
 import os
 import math
 import uuid
 import logging
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import opentimelineio as otio
 
@@ -20,7 +21,7 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-def get_vendored_env() -> Dict[str, Any]:
+def get_vendored_env() -> dict[str, Any]:
     """Get a prepared copy of the current environment.
 
     Checks for the presence of ``$OCIO``, ``$LABLIB_OIIO`` and ``$LABLIB_FFMPEG`` and adds them to ``$PATH``.
@@ -30,7 +31,7 @@ def get_vendored_env() -> Dict[str, Any]:
         Run ``.\start.ps1 get-dependencies`` to download the vendored files.
 
     Returns:
-        Dict[str, Any]
+        dict[str, Any]
     """
     _parts = Path(__file__).parts[:-3]
     vendor_root = Path(*_parts, "vendor")
@@ -77,11 +78,11 @@ def get_vendored_env() -> Dict[str, Any]:
     return env
 
 
-def call_cmd(cmd: List[str], timeout=None, retries=0) -> Optional[str]:
+def call_cmd(cmd: list[str], timeout=None, retries=0) -> Optional[str]:
     """Run a syscall and return the output and error.
 
     :param cmd: The command to run.
-    :type cmd: List[str]
+    :type cmd: list[str]
     """
     out, err, proc = None, None, None
     env = get_vendored_env()
@@ -213,42 +214,42 @@ def get_staging_dir() -> str:
     )
 
 
-def zero_matrix() -> List[List[float]]:
+def zero_matrix() -> list[list[float]]:
     return [[0.0] * 3 for _ in range(3)]
 
 
-def identity_matrix() -> List[List[float]]:
+def identity_matrix() -> list[list[float]]:
     return translate_matrix([0.0, 0.0])
 
 
-def translate_matrix(t: List[float]) -> List[List[float]]:
+def translate_matrix(t: list[float]) -> list[list[float]]:
     return [[1.0, 0.0, t[0]], [0.0, 1.0, t[1]], [0.0, 0.0, 1.0]]
 
 
-def rotate_matrix(r: float) -> List[List[float]]:
+def rotate_matrix(r: float) -> list[list[float]]:
     rad = math.radians(r)
     cos = math.cos(rad)
     sin = math.sin(rad)
     return [[cos, -sin, 0.0], [sin, cos, 0.0], [0.0, 0.0, 1.0]]
 
 
-def scale_matrix(s: List[float]) -> List[List[float]]:
+def scale_matrix(s: list[float]) -> list[list[float]]:
     return [[s[0], 0.0, 0.0], [0.0, s[1], 0.0], [0.0, 0.0, 1.0]]
 
 
-def mirror_matrix(x: bool = False) -> List[List[float]]:
+def mirror_matrix(x: bool = False) -> list[list[float]]:
     direction = [1.0, -1.0] if not x else [-1.0, 1.0]
     return scale_matrix(direction)
 
 
-def mult_matrix(m1: List[List[float]], m2: List[List[float]]) -> List[List[float]]:
+def mult_matrix(m1: list[list[float]], m2: list[list[float]]) -> list[list[float]]:
     return [
         [sum(a * b for a, b in zip(m1_row, m2_col)) for m2_col in zip(*m2)]
         for m1_row in m1
     ]
 
 
-def mult_matrix_vector(m: List[List[float]], v: List[float]) -> List[float]:
+def mult_matrix_vector(m: list[list[float]], v: list[float]) -> list[float]:
     result = [0.0, 0.0, 0.0]
     for i in range(len(m)):
         for j in range(len(v)):
@@ -256,7 +257,7 @@ def mult_matrix_vector(m: List[List[float]], v: List[float]) -> List[float]:
     return result
 
 
-def flip_matrix(w: float) -> List[List[float]]:
+def flip_matrix(w: float) -> list[list[float]]:
     result = identity_matrix()
     chain = [translate_matrix([w, 0.0]), mirror_matrix(x=True)]
     for m in chain:
@@ -264,7 +265,7 @@ def flip_matrix(w: float) -> List[List[float]]:
     return result
 
 
-def flop_matrix(h: float) -> List[List[float]]:
+def flop_matrix(h: float) -> list[list[float]]:
     result = identity_matrix()
     chain = [translate_matrix([0.0, h]), mirror_matrix()]
     for m in chain:
@@ -272,7 +273,7 @@ def flop_matrix(h: float) -> List[List[float]]:
     return result
 
 
-def transpose_matrix(m: List[List[float]]) -> List[List[float]]:
+def transpose_matrix(m: list[list[float]]) -> list[list[float]]:
     res = identity_matrix()
     for i in range(len(m)):
         for j in range(len(m[0])):
@@ -280,7 +281,7 @@ def transpose_matrix(m: List[List[float]]) -> List[List[float]]:
     return res
 
 
-def matrix_to_44(m: List[List[float]]) -> List[List[float]]:
+def matrix_to_44(m: list[list[float]]) -> list[list[float]]:
     result = m
     result[0].insert(2, 0.0)
     result[1].insert(2, 0.0)
@@ -289,7 +290,7 @@ def matrix_to_44(m: List[List[float]]) -> List[List[float]]:
     return result
 
 
-def matrix_to_list(m: List[List[float]]) -> List[float]:
+def matrix_to_list(m: list[list[float]]) -> list[float]:
     result = []
     for i in m:
         for j in i:
@@ -297,7 +298,7 @@ def matrix_to_list(m: List[List[float]]) -> List[float]:
     return result
 
 
-def matrix_to_csv(m: List[List[float]]) -> str:
+def matrix_to_csv(m: list[list[float]]) -> str:
     l = []
     for i in m:
         for k in i:
@@ -306,8 +307,8 @@ def matrix_to_csv(m: List[List[float]]) -> str:
 
 
 def matrix_to_cornerpin(
-    m: List[List[float]], w: int, h: int, origin_upperleft: bool = True
-) -> List:
+    m: list[list[float]], w: int, h: int, origin_upperleft: bool = True
+) -> list:
     cornerpin = []
     if origin_upperleft:
         corners = [[0, h, 1], [w, h, 1], [0, 0, 1], [w, 0, 1]]
@@ -323,8 +324,8 @@ def matrix_to_cornerpin(
 
 
 def calculate_matrix(
-    t: List[float], r: float, s: List[float], c: List[float]
-) -> List[List[float]]:
+    t: list[float], r: float, s: list[float], c: list[float]
+) -> list[list[float]]:
     c_inv = [-c[0], -c[1]]
     center = translate_matrix(c)
     center_inv = translate_matrix(c_inv)

--- a/lablib/operators/color.py
+++ b/lablib/operators/color.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import PyOpenColorIO as OCIO
 
@@ -128,7 +130,7 @@ class OCIOFileTransform(ColorOperator):
             data? Would they even be so much different?
 
         Args:
-            data (dict): The node data. List of expected but not required keys:
+            data (dict): The node data. list of expected but not required keys:
                 - file (str): Path to the LUT file.
                 - cccid (str): Path to the cccid file.
                 - direction (int): The direction. Defaults to 0.
@@ -159,9 +161,9 @@ class OCIOCDLTransform(OCIOFileTransform):
         file (Optional[str]): Path to the LUT file.
         direction (int): The direction. Defaults to 0.
         cccid (str): The cccid. Defaults to "".
-        offset (List[float]): The offset. Defaults to [0.0, 0.0, 0.0].
-        power (List[float]): The power. Defaults to [1.0, 1.0, 1.0].
-        slope (List[float]): The slope. Defaults to [0.0, 0.0, 0.0].
+        offset (list[float]): The offset. Defaults to [0.0, 0.0, 0.0].
+        power (list[float]): The power. Defaults to [1.0, 1.0, 1.0].
+        slope (list[float]): The slope. Defaults to [0.0, 0.0, 0.0].
         saturation (float): The saturation. Defaults to 1.0.
         interpolation (str): The interpolation. Defaults to "linear".
     """
@@ -169,9 +171,9 @@ class OCIOCDLTransform(OCIOFileTransform):
     file: Optional[str] = None
     direction: int = 0
     cccid: str = ""
-    offset: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
-    power: List[float] = field(default_factory=lambda: [1.0, 1.0, 1.0])
-    slope: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    offset: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    power: list[float] = field(default_factory=lambda: [1.0, 1.0, 1.0])
+    slope: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
     saturation: float = 1.0
     interpolation: str = "linear"
 
@@ -212,17 +214,17 @@ class OCIOCDLTransform(OCIOFileTransform):
         """Create :obj:`OCIOCDLTransform` from node data.
 
         Args:
-            data (dict): The node data. List of expected but not required keys:
+            data (dict): The node data. list of expected but not required keys:
                 - file (str): Path to the LUT file.
                 - direction (int): The direction.
                     Defaults to 0.
                 - cccid (str): The cccid.
                     Defaults to "".
-                - offset (List[float]): The offset.
+                - offset (list[float]): The offset.
                     Defaults to [0.0, 0.0, 0.0].
-                - power (List[float]): The power.
+                - power (list[float]): The power.
                     Defaults to [1.0, 1.0, 1.0].
-                - slope (List[float]): The slope.
+                - slope (list[float]): The slope.
                     Defaults to [0.0, 0.0, 0.0].
                 - saturation (float): The saturation.
                     Defaults to 1.0.

--- a/lablib/operators/repositions.py
+++ b/lablib/operators/repositions.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from typing import List
 
 from lablib.lib.utils import (
     identity_matrix,
@@ -33,11 +32,11 @@ class RepositionOperator(BaseOperator):
         pass
 
     @abstractmethod
-    def to_oiio_args(self) -> List[str]:
+    def to_oiio_args(self) -> list[str]:
         """An abstract method for returning the arguments for ``oiiotool``.
 
         Returns:
-            List[str]: Arguments for OIIO.
+            list[str]: Arguments for OIIO.
         """
         pass
 
@@ -53,10 +52,10 @@ class Transform(RepositionOperator):
         The :obj:`Transform.skew_order` parameter determines the order in which the skewX and skewY transformations are applied.
 
     Attributes:
-        translate (List[float]): The translation vector.
+        translate (list[float]): The translation vector.
         rotate (float): The rotation angle in degrees.
-        scale (List[float]): The scaling vector.
-        center (List[float]): The center of the transformation.
+        scale (list[float]): The scaling vector.
+        center (list[float]): The center of the transformation.
         invert (bool): Invert the transformation.
         skewX (float): The skew in the X direction.
         skewY (float): The skew in the Y direction.
@@ -64,23 +63,23 @@ class Transform(RepositionOperator):
             transformations are applied.
     """
 
-    translate: List[float] = field(default_factory=lambda: [0.0, 0.0])
+    translate: list[float] = field(default_factory=lambda: [0.0, 0.0])
     rotate: float = 0.0
     # needs to be treated as a list of floats but can be single float
-    scale: List[float] = field(default_factory=lambda: [1.0, 1.0])
-    center: List[float] = field(default_factory=lambda: [0.0, 0.0])
+    scale: list[float] = field(default_factory=lambda: [1.0, 1.0])
+    center: list[float] = field(default_factory=lambda: [0.0, 0.0])
     invert: bool = False
     skewX: float = 0.0
     skewY: float = 0.0
     skew_order: str = "XY"
 
-    def to_oiio_args(self) -> List[str]:
+    def to_oiio_args(self) -> list[str]:
         """Gets the arguments for ``oiiotool``.
 
         Uses :obj:`lablib.lib` to work with transformation matrices.
 
         Returns:
-            List[str]: Arguments for OIIO.
+            list[str]: Arguments for OIIO.
         """
         matrix = calculate_matrix(
             t=self.translate, r=self.rotate, s=self.scale, c=self.center
@@ -123,17 +122,17 @@ class Crop(RepositionOperator):
     """Operator for cropping images.
 
     Attributes:
-        box (List[int]): The crop box.
+        box (list[int]): The crop box.
     """
 
-    box: List[int] = field(default_factory=lambda: [0, 0, 1920, 1080])
+    box: list[int] = field(default_factory=lambda: [0, 0, 1920, 1080])
     # NOTE: could also be called with width, height, x, y
 
-    def to_oiio_args(self) -> List[str]:
+    def to_oiio_args(self) -> list[str]:
         """Gets the arguments for ``oiiotool``.
 
         Returns:
-            List[int]: Arguments for OIIO.
+            list[int]: Arguments for OIIO.
         """
         return [
             "--crop",
@@ -173,7 +172,7 @@ class Mirror2(RepositionOperator):
         """Gets the arguments for ``oiiotool``.
 
         Returns:
-            List[str]: Arguments for OIIO.
+            list[str]: Arguments for OIIO.
         """
         args = []
         if self.flop:
@@ -203,30 +202,30 @@ class CornerPin2D(RepositionOperator):
         This operator is not yet tested or used in the codebase.
 
     Attributes:
-        from1 (List[float]): The first corner of the source image.
-        from2 (List[float]): The second corner of the source image.
-        from3 (List[float]): The third corner of the source image.
-        from4 (List[float]): The fourth corner of the source image.
-        to1 (List[float]): The first corner of the destination image.
-        to2 (List[float]): The second corner of the destination image.
-        to3 (List[float]): The third corner of the destination image.
-        to4 (List[float]): The fourth corner of the destination image.
+        from1 (list[float]): The first corner of the source image.
+        from2 (list[float]): The second corner of the source image.
+        from3 (list[float]): The third corner of the source image.
+        from4 (list[float]): The fourth corner of the source image.
+        to1 (list[float]): The first corner of the destination image.
+        to2 (list[float]): The second corner of the destination image.
+        to3 (list[float]): The third corner of the destination image.
+        to4 (list[float]): The fourth corner of the destination image.
     """
 
-    from1: List[float] = field(default_factory=lambda: [0.0, 0.0])
-    from2: List[float] = field(default_factory=lambda: [0.0, 0.0])
-    from3: List[float] = field(default_factory=lambda: [0.0, 0.0])
-    from4: List[float] = field(default_factory=lambda: [0.0, 0.0])
-    to1: List[float] = field(default_factory=lambda: [0.0, 0.0])
-    to2: List[float] = field(default_factory=lambda: [0.0, 0.0])
-    to3: List[float] = field(default_factory=lambda: [0.0, 0.0])
-    to4: List[float] = field(default_factory=lambda: [0.0, 0.0])
+    from1: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    from2: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    from3: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    from4: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    to1: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    to2: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    to3: list[float] = field(default_factory=lambda: [0.0, 0.0])
+    to4: list[float] = field(default_factory=lambda: [0.0, 0.0])
 
     def to_oiio_args(self):
         """Gets the arguments for ``oiiotool``.
 
         Returns:
-            List[str]: Arguments for OIIO.
+            list[str]: Arguments for OIIO.
         """
         # TODO: use matrix operation from utils.py
         return []

--- a/lablib/processors/ayon_hiero_effect_file.py
+++ b/lablib/processors/ayon_hiero_effect_file.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import inspect
-
-from typing import List, Dict
 from pathlib import Path
 import PyOpenColorIO as OCIO
 
@@ -29,8 +27,8 @@ class AYONHieroEffectsFileProcessor(object):
 
     _wrapper_class_members = dict(
         inspect.getmembers(operators, inspect.isclass))
-    _color_ops: List = []
-    _repo_ops: List = []
+    _color_ops: list = []
+    _repo_ops: list = []
 
     def __init__(
         self,
@@ -46,16 +44,16 @@ class AYONHieroEffectsFileProcessor(object):
         self.load()
 
     @property
-    def ocio_objects(self) -> List:
-        """List of OCIO objects to be processed."""
+    def ocio_objects(self) -> list:
+        """list of OCIO objects to be processed."""
         ops = []
         for op in self._color_ops:
             ops.append(op.to_ocio_obj())
         return ops
 
     @property
-    def repo_operators(self) -> Dict:
-        """List of repositioning operators to be processed."""
+    def repo_operators(self) -> dict:
+        """list of repositioning operators to be processed."""
         return self._repo_ops
 
     def load(self) -> None:
@@ -137,7 +135,7 @@ class AYONHieroEffectsFileProcessor(object):
         self._color_ops = []
         self._repo_ops = []
 
-    def get_oiiotool_cmd(self) -> List[str]:
+    def get_oiiotool_cmd(self) -> list[str]:
         """Returns arguments for oiiotool command."""
         args = []
         for oo in self.ocio_objects:

--- a/lablib/processors/ayon_ociolook_file.py
+++ b/lablib/processors/ayon_ociolook_file.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 
-from typing import List
 from pathlib import Path
 import PyOpenColorIO as OCIO
 
@@ -28,7 +27,7 @@ class AYONOCIOLookFileProcessor(object):
     target_path: Path = None
     log: logging.Logger = log
 
-    _ocio_objects: List[OCIO.Transform] = []
+    _ocio_objects: list[OCIO.Transform] = []
 
     def __init__(
         self,
@@ -44,8 +43,8 @@ class AYONOCIOLookFileProcessor(object):
         self.load()
 
     @property
-    def ocio_objects(self) -> List:
-        """List of OCIO objects to be processed."""
+    def ocio_objects(self) -> list:
+        """list of OCIO objects to be processed."""
         return self._ocio_objects
 
     def clear_ocio_objects(self) -> None:
@@ -137,7 +136,7 @@ class AYONOCIOLookFileProcessor(object):
                 )
             )
 
-    def get_oiiotool_cmd(self) -> List[str]:
+    def get_oiiotool_cmd(self) -> list[str]:
         """Get arguments for the OIIO command."""
         args = []
         for oo in self.ocio_objects:

--- a/lablib/processors/oiio_repositions.py
+++ b/lablib/processors/oiio_repositions.py
@@ -1,10 +1,9 @@
 """Processors providing positional effect arguments for OIIO."""
-
 from __future__ import annotations
 
 import inspect
 import logging
-from typing import Any, List
+from typing import Any
 
 from ..operators import repositions
 
@@ -21,7 +20,7 @@ class OIIORepositionProcessor:
         This way :obj:`OIIORepositionProcessor` will act as a basic reformat.
 
     Attributes:
-        operators (List): The list of repositioning operators.
+        operators (list): The list of repositioning operators.
         src_width (int): The source image width.
         dst_width (int): The destination image width.
         src_height (int): The source image height.
@@ -29,7 +28,7 @@ class OIIORepositionProcessor:
         fit (str): The fit mode for the image.
     """
 
-    operators: List[Any] = []
+    operators: list[Any] = []
     src_width: int = 0
     dst_width: int = 0
     src_height: int = 0
@@ -52,11 +51,11 @@ class OIIORepositionProcessor:
 
         return f"{self.__class__.__name__}({props[:-2]})"
 
-    def get_oiiotool_cmd(self) -> List[str]:
+    def get_oiiotool_cmd(self) -> list[str]:
         """Get the OIIO arguments for repositioning images.
 
         Returns:
-            List[str]: The OIIO arguments.
+            list[str]: The OIIO arguments.
         """
         result = []
         for op in self.operators:

--- a/lablib/renderers/basic.py
+++ b/lablib/renderers/basic.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 import logging
 import shutil
 import tempfile
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Optional, Set, Union
 
 from pathlib import Path
 
@@ -41,7 +41,7 @@ class Codec:
                 f"codecs.\n{SUPPORTED_CODECS = }"
             )
 
-    def get_ffmpeg_args(self) -> List[str]:
+    def get_ffmpeg_args(self) -> list[str]:
         """Get the ffmpeg arguments for the codec.
 
         TODO:
@@ -49,7 +49,7 @@ class Codec:
               settings of ``Extract Review``.
 
         Returns:
-            List[str]: The ffmpeg arguments.
+            list[str]: The ffmpeg arguments.
         """
         args = []
         # fmt: off
@@ -101,7 +101,7 @@ class Burnin:
             },
 
     Attributes:
-        data (Dict[str, str]): The text to be drawn and its positioning.
+        data (dict[str, str]): The text to be drawn and its positioning.
         size (int): The size of the text.
         padding (int): The padding around the text.
         color (Set[float]): The color of the text.
@@ -109,7 +109,7 @@ class Burnin:
         outline (Optional[int]): The outline size.
     """
 
-    data: Dict[str, str] = field(default_factory=dict)
+    data: dict[str, str] = field(default_factory=dict)
 
     size: int = field(default=64)
     padding: int = field(default=30)
@@ -125,11 +125,11 @@ class Burnin:
         if self.font:
             self._font = Path(self.font).resolve()
 
-    def get_oiiotool_args(self) -> List[str]:
+    def get_oiiotool_args(self) -> list[str]:
         """Get the OIIO arguments.
 
         Returns:
-            List[str]:
+            list[str]:
         """
         args = []
         width_token = r"{TOP.width}"
@@ -247,14 +247,14 @@ class BasicRenderer(RendererBase):
 
         return f"{self.__class__.__name__}({props[:-2]})"
 
-    def get_oiiotool_cmd(self, debug=False) -> List[str]:
+    def get_oiiotool_cmd(self, debug=False) -> list[str]:
         """Get arguments for rendering with OIIO.
 
         Arguments:
             debug (Optional[bool]): Whether to increase log verbosity.
 
         Returns:
-            List[str]: The OIIO arguments.
+            list[str]: The OIIO arguments.
         """
         input_path = Path(
             self.source_sequence.path, self.source_sequence.hash_string
@@ -285,11 +285,11 @@ class BasicRenderer(RendererBase):
 
         return cmd
 
-    def get_ffmpeg_cmd(self) -> List[str]:
+    def get_ffmpeg_cmd(self) -> list[str]:
         """Get arguments for rendering with ffmpeg.
 
         Returns:
-            List[str]: The ffmpeg arguments.
+            list[str]: The ffmpeg arguments.
         """
         cmd = ["ffmpeg", "-loglevel", "info", "-hide_banner"]
 

--- a/lablib/renderers/slate_render.py
+++ b/lablib/renderers/slate_render.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import subprocess
 import shutil
-from typing import List
 
 from pathlib import Path
 
@@ -25,7 +24,7 @@ class SlateRenderer(RendererBase):
                 # data used to fill up the slate template
                 {
                     "project": {"name": "test_project"},
-                    "intent": {"value": "test_intent"},            
+                    "intent": {"value": "test_intent"},
                     "task": {"short": "test_task"},
                     "asset": "test_asset",
                     "comment": "some random comment",
@@ -54,8 +53,8 @@ class SlateRenderer(RendererBase):
         self._source_sequence = None
         self.source_sequence = source_sequence
 
-        self._thumbs: List = None
-        self._command: List = []
+        self._thumbs: list = None
+        self._command: list = []
 
     @property
     def slate_generator(self) -> SlateHtmlGenerator:
@@ -111,7 +110,7 @@ class SlateRenderer(RendererBase):
 
         Arguments:
             debug (Optional[bool]): Whether to increase log verbosity.
-        """        
+        """
         first_frame = min(self.source_sequence.imageinfos)
         timecode = offset_timecode(
             tc=first_frame.timecode,

--- a/tests/test_operators_reposition.py
+++ b/tests/test_operators_reposition.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import logging
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 import pytest
 
@@ -15,7 +17,7 @@ class TestRepositionOperators:
 
     def __get_reposition_operators(
         file: Union[Path, str], type: str = None
-    ) -> List[dict]:
+    ) -> list[dict]:
         """Helper function to read reposition operators from effectsjson files.
         NOTE: should i use a fixture for this and can i mix fixtures
         """


### PR DESCRIPTION
Updates type hints in several modules to use `list` and `dict`
instead of `List` and `Dict` for improved code clarity and
consistency with modern Python practices.