### PR TITLE
use oiiotool from pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The core functionality relies on using **Processors** and **Operators** to compu
 ## Installation
 LabLib requires `python-3.9` and uses `poetry` for managing its dependencies.
 
-It's encouraged to use the provided PowerShell script to install and download the binaries for [oiiotool](https://www.patreon.com/posts/openimageio-oiio-63609827), [ffmpeg](https://github.com/GyanD/codexffmpeg/releases/tag/7.0.1), the [OCIO Color Configs](https://github.com/colour-science/OpenColorIO-Configs/releases/tag/v1.2) and the font [Source Code Pro](https://fontsource.org/fonts/source-code-pro) which is used in tests.
+It's encouraged to use the provided PowerShell script to install and download the binaries for [ffmpeg](https://github.com/GyanD/codexffmpeg/releases/tag/7.0.1), the [OCIO Color Configs](https://github.com/colour-science/OpenColorIO-Configs/releases/tag/v1.2) and the font [Source Code Pro](https://fontsource.org/fonts/source-code-pro) which is used in tests.
 
 - clone this repo
 - `.\start.ps1 install`

--- a/lablib/lib/utils.py
+++ b/lablib/lib/utils.py
@@ -51,12 +51,6 @@ def get_vendored_env() -> dict[str, Any]:
         env["OCIO"] = str(ocio_path)
         log.debug(f"{env['OCIO'] = }")
 
-    if oiio_root := env.get("LABLIB_OIIO"):
-        log.debug(f"Using oiiotool from {oiio_root}")
-    else:
-        log.info("LABLIB_OIIO environment variable not set. Using default.")
-        oiio_root = Path(vendor_root, "oiio", "windows")
-
     if ffmpeg_root := env.get("LABLIB_FFMPEG"):
         log.debug(f"Using ffmpeg from {ffmpeg_root}")
     else:
@@ -66,9 +60,6 @@ def get_vendored_env() -> dict[str, Any]:
         )
 
     paths = [Path(p) for p in env["PATH"].split(";")]
-    if oiio_root not in paths:
-        paths.insert(0, oiio_root)
-        log.debug(f"Insert into $PATH {oiio_root = }")
     if ffmpeg_root not in paths:
         log.debug(f"Insert into $PATH {ffmpeg_root = }")
         paths.insert(0, ffmpeg_root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python = ">=3.9.1,<3.10"
 opentimelineio = "^0.16.0"
 opencolorio = "<=2.3.2"
 selenium = "4.16.0"
+openimageio = "^3.1.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.0"

--- a/start.ps1
+++ b/start.ps1
@@ -97,14 +97,6 @@ function get_dependencies {
         New-Item -ItemType Directory -Path $vendor_root
     }
 
-    # ensure OpenImageIO
-    if (-not (Test-Path "$vendor_root\oiio\windows\oiiotool.exe")) {
-        $oiio_url = "https://www.patreon.com/file?h=63609827&i=10247677"
-        $oiio_zip = "$vendor_root\oiiotools2.3.10.zip"
-        Invoke-WebRequest -Uri $oiio_url -OutFile $oiio_zip
-        Expand-Archive -Path $oiio_zip -DestinationPath "$vendor_root\oiio\windows"
-    }
-
     # ensure OpenColorIO Config
     if (-not (Test-Path "$vendor_root\ocioconfig")) {
         $ocio_url = "https://github.com/colour-science/OpenColorIO-Configs/releases/download/v1.2/OpenColorIO-Config-ACES-1.2.zip"


### PR DESCRIPTION
## Changelog Description
This PR introduces usage of officially available `oiiotool` binaries from pypi

## Additional review information
The binaries we formerly used are now offline. All references to it have been removed.

refs https://github.com/ynput/LabLib/issues/44